### PR TITLE
Fix: ask to replace files + fonts folder management

### DIFF
--- a/nf_downloader.sh
+++ b/nf_downloader.sh
@@ -166,7 +166,7 @@ download_and_install_font() {
 
   case $distro in
     "osx") font_dir="/Library/Fonts";;
-    *) font_dir="${HOME}/.local/share/fonts"; mkdir -p "$font_dir";;
+    *) font_dir="${HOME}/.local/share/fonts/${selected_font}"; mkdir -p "$font_dir"; echo "font dir '$font_dir' created ";;
   esac
 
   echo "Downloading and installing '$selected_font'..."


### PR DESCRIPTION
Issue: 
Script is asking to replace files when installing all fonts  

```
...
Downloading and installing 'RobotoMono'...
replace /home/$HOME/.local/share/fonts/LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'RobotoMono' installed successfully.
Downloading and installing 'ShareTechMono'...
replace /home/$HOME/.local/share/fonts/OFL.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'ShareTechMono' installed successfully.
Downloading and installing 'SourceCodePro'...
replace /home/$HOME/.local/share/fonts/LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'SourceCodePro' installed successfully.
Downloading and installing 'SpaceMono'...
replace /home/$HOME/.local/share/fonts/OFL.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'SpaceMono' installed successfully.
Downloading and installing 'Terminus'...
replace /home/$HOME/.local/share/fonts/LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'Terminus' installed successfully.
Downloading and installing 'Tinos'...
replace /home/$HOME/.local/share/fonts/README.md? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'Tinos' installed successfully.
Downloading and installing 'Ubuntu'...
replace /home/$HOME/.local/share/fonts/README.md? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'Ubuntu' installed successfully.
Downloading and installing 'UbuntuMono'...
replace /home/$HOME/.local/share/fonts/LICENCE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'UbuntuMono' installed successfully.
Downloading and installing 'VictorMono'...
replace /home/$HOME/.local/share/fonts/LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename: A
'VictorMono' installed successfully.
Font cache updated.
```

Solution :
Install every font in its own folder