### PR TITLE
Updating for Ubuntu compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _Note: If you already have one, it will proceed with the process._
 - `tar`
 - `fontconfig`
 - `jq`
+- `curl` 
 
 ### Supported Distributions
 

--- a/nf_downloader.sh
+++ b/nf_downloader.sh
@@ -71,7 +71,7 @@ declare -a fonts=(
 
 # Function to install dependencies on different distros
 install_dependencies() {
-  local dependencies=("wget" "unzip" "tar" "fontconfig" "jq")
+  local dependencies=("curl" "wget" "unzip" "tar" "fontconfig" "jq")
   local install_message="Installing dependencies. Please wait..."
 
   echo "$install_message"


### PR DESCRIPTION
Ubuntu 25.10 does not include curl on the default install, and curl is not listed in the README.md as a dependency. This branch adds curl to the list of dependencies in both the dependencies array in the script, and the list of dependencies in the README.